### PR TITLE
fix: add sanity checks

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -11,10 +11,15 @@ init(){
     TM_VERSION=$(cat /tmp/gh_output |jq -r .name|sed 's/^v//')
   fi
 
-  curl -sLO "https://github.com/terramate-io/terramate/releases/download/v${TM_VERSION}/terramate_${TM_VERSION}_linux_x86_64.tar.gz"
+  dl_url="https://github.com/terramate-io/terramate/releases/download/v${TM_VERSION}/terramate_${TM_VERSION}_linux_x86_64.tar.gz"
+  status_code=$(curl -LsI -o /dev/null -w "%{http_code}"  $dl_url)
+  [[ $status_code != 200 ]] && fatal "Download URL ($dl_url) returns $status_code"
+  curl -sLO $dl_url
   tar xzf "terramate_${TM_VERSION}_linux_x86_64.tar.gz" -C /tmp
   mv /tmp/terramate /usr/local/bin/terramate-bin
   rm "terramate_${TM_VERSION}_linux_x86_64.tar.gz"
+  [[ $TM_VERSION != $(terramate-bin --version) ]] && fatal "Something went wrong downloading Terramate from $dl_url"
+
   cat > /usr/local/bin/terramate-wrapper <<EOF
 #!/bin/bash
 terramate-bin \$* > /tmp/stdout 2> /tmp/stderr


### PR DESCRIPTION
Fail if Terramate doesn't download/extract successfully.