### PR TITLE
fix: wrapper as separate script and other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # Terramate Github Action
 
-This is a very simple Github Action that installs Terramate and allows you run any command and retrieve the stdout, stderr and exit code in subsequent commands. It is only compatible with Ubuntu runners.
+This is a very simple Github Action that installs Terramate and (optionally) a wrapper that allows you to use the stdout, stderr and exit code in subsequent workflow steps. It is only compatible with Ubuntu runners.
 
 ## Usage
 
-There are three optional inputs
-* `tm_version` is the version of Terramate to use, defaulting to the latest 
+There are two optional inputs
+* `version` is the version of Terramate to use, defaulting to the latest 
 * `use_wrapper` if explicitly set to "false" Terramate will not be installed via a wrapper script (meaning you will have no access to the outputs)
 
 Outputs are `stdout`, `stderr` and `exitcode` which can be used in subsequent commands, e.g.
 
 ```
+      - name: Install terramate
+        uses: terramate-io/terramate-action@main
       - name: Terramate run plan
         id: plan
         run: terramate run --changed --disable-check-gen-code -- terraform plan -lock-timeout=5m -out out.tfplan

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'Terramate'
 description: 'Terramate'
 inputs:
-  tm_version:
+  version:
     description: 'Terramate version'
     required: false
     default: latest
@@ -25,8 +25,8 @@ runs:
     - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
       shell: bash
     - id: run
-      run: main.sh
+      run: install.sh
       shell: bash
       env:
-        TM_VERSION:  ${{inputs.tm_version}}
+        TM_VERSION:  ${{inputs.version}}
         USE_WRAPPER: ${{inputs.use_wrapper}}

--- a/install.sh
+++ b/install.sh
@@ -1,47 +1,35 @@
 #!/bin/bash
 
 fatal(){
-  echo $*
+  echo "$*"
   exit 1
 }
 
-init(){
+install(){
   if [[ $TM_VERSION == "latest" ]]; then
     curl -s https://api.github.com/repos/terramate-io/terramate/releases/latest > /tmp/gh_output || fatal "couldn't get Terramate release data from github"
-    TM_VERSION=$(cat /tmp/gh_output |jq -r .name|sed 's/^v//')
+    TM_VERSION=$(jq -r .name /tmp/gh_output|sed 's/^v//')
   fi
 
   dl_url="https://github.com/terramate-io/terramate/releases/download/v${TM_VERSION}/terramate_${TM_VERSION}_linux_x86_64.tar.gz"
-  status_code=$(curl -LsI -o /dev/null -w "%{http_code}"  $dl_url)
+  status_code=$(curl -LsI -o /dev/null -w "%{http_code}"  "$dl_url")
   [[ $status_code != 200 ]] && fatal "Download URL ($dl_url) returns $status_code"
-  curl -sLO $dl_url
+  curl -sLO "$dl_url"
   tar xzf "terramate_${TM_VERSION}_linux_x86_64.tar.gz" -C /tmp
   mv /tmp/terramate /usr/local/bin/terramate-bin
   rm "terramate_${TM_VERSION}_linux_x86_64.tar.gz"
   [[ $TM_VERSION != $(terramate-bin --version) ]] && fatal "Something went wrong downloading Terramate from $dl_url"
 
-  cat > /usr/local/bin/terramate-wrapper <<EOF
-#!/bin/bash
-terramate-bin \$* > /tmp/stdout 2> /tmp/stderr
-exitcode=\$?
-echo "exitcode=\$exitcode" >> "\$GITHUB_OUTPUT"
-echo 'stdout<<EOF' >> "\$GITHUB_OUTPUT"
-cat /tmp/stdout |tee -a "\$GITHUB_OUTPUT"
-echo EOF >> "\$GITHUB_OUTPUT"
-echo 'stderr<<EOF' >> "\$GITHUB_OUTPUT"
-cat /tmp/stderr |tee -a "\$GITHUB_OUTPUT"
-echo EOF >> "\$GITHUB_OUTPUT"
-EOF
-  chmod +x /usr/local/bin/terramate-wrapper
+  cp "$GITHUB_ACTION_PATH/terramate-wrapper.sh" /usr/local/bin/terramate-wrapper.sh
   if [[ $USE_WRAPPER == "false" ]]; then
     ln /usr/local/bin/terramate-bin /usr/local/bin/terramate 
   else
-    ln /usr/local/bin/terramate-wrapper /usr/local/bin/terramate
+    ln /usr/local/bin/terramate-wrapper.sh /usr/local/bin/terramate
   fi
-  echo $TM_VERSION > /tmp/init-has-run
+  echo "$TM_VERSION" > /tmp/init-has-run
 }
 
-if [[ $(cat /tmp/init-has-run 2>/dev/null ) != $TM_VERSION ]]; then
+if [[ $(cat /tmp/init-has-run 2>/dev/null ) != "$TM_VERSION" ]]; then
   echo "# Installing Terramate"
-  init
+  install
 fi

--- a/terramate-wrapper.sh
+++ b/terramate-wrapper.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+terramate-bin "$@" > >(tee /tmp/stdout) 2> >(tee /tmp/stderr)
+exitcode=$?
+echo "exitcode=$exitcode" >> "$GITHUB_OUTPUT"
+echo 'stdout<<EOF' >> "$GITHUB_OUTPUT"
+cat /tmp/stdout >> "$GITHUB_OUTPUT"
+echo EOF >> "$GITHUB_OUTPUT"
+echo 'stderr<<EOF' >> "$GITHUB_OUTPUT"
+cat /tmp/stderr >> "$GITHUB_OUTPUT"
+echo EOF >> "$GITHUB_OUTPUT"
+exit $exitcode
+


### PR DESCRIPTION
* wrapper as separate script
* wrapper output uses `tee` inside subshells for the redirects to maintain correct order of output
* remove `tm_` prefix
* bug where using 'bash -c' in `run` was failing