### PR TITLE
fix: install supported Terramate system/arch (excluding windows).

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,8 +127,6 @@ jobs:
         with:
           version: ${{ matrix.version }}
           use_wrapper: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate execution - ${{ matrix.version }}
         run: terramate version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   simple:
     name: Default action without asdf config should fail.
@@ -17,6 +20,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      
+      - if: runner.os == 'macOS'
+        name: "install jq on macos"
+        run: brew install jq
 
       - name: Install latest Terramate (this will fail)
         id: install
@@ -28,13 +35,18 @@ jobs:
 
   asdf:
     name: Terramate asdf
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: [0.13.3, 0.14.0, skip]
+        os: ["ubuntu-latest", "macos-latest"]
+        version: [0.13.3, 0.14.7, skip]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - if: runner.os == 'macOS'
+        name: "install jq on macos"
+        run: brew install jq
 
       - name: Prepare asdf config
         if: ${{ matrix.version != 'skip' }}
@@ -73,10 +85,11 @@ jobs:
 
   wrapper:
     name: Terramate with wrapper
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: [0.14.0, latest]
+        os: ["ubuntu-latest", "macos-latest"]
+        version: [0.14.7, latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -100,10 +113,11 @@ jobs:
 
   no-wrapper:
     name: Terramate without wrapper
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: [0.14.0, latest]
+        os: ["ubuntu-latest", "macos-latest"]
+        version: [0.14.7, latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -113,6 +127,8 @@ jobs:
         with:
           version: ${{ matrix.version }}
           use_wrapper: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate execution - ${{ matrix.version }}
         run: terramate version

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ The [`terramate-io/terramate-action`] is a GitHub composite action that sets up 
 - It installs a wrapper script by default so that calls to `terramate` binary will expose GitHub Action outputs to access the `stderr`, `stderr`, and the `exitcode` of the `terramate` execution.
 - It allows you to configure a default [Terramate Cloud] organization to use Terramate Cloud Features like Drift Detection and Stack Health Information.
 
-## Compatbility
+## Compatibility
 
-The action currently only supports `ubuntu` runners.
+The action currently only supports `ubuntu` and `macos` runners.
 
 ## Usage
 

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ get_latest_version() {
   echo >&2 "get_latest_version: Getting latest Terramate release information from GitHub Releases"
 
   latest_url="https://api.github.com/repos/terramate-io/terramate/releases/latest"
-  latest_json=$(curl -s "${latest_url}")
+  latest_json=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" "${latest_url}")
   tag_version=$(jq -r .tag_name <<<"${latest_json}")
 
   if [ -z "${tag_version}" ] || [ "${tag_version}" == "null" ] ; then
@@ -81,7 +81,29 @@ install() {
   tmpdir=$(mktemp -d)
   echo >&2 "install: Created tmp directory at ${tmpdir}"
 
-  url="https://github.com/terramate-io/terramate/releases/download/v${version}/terramate_${version}_linux_x86_64.tar.gz"
+  system=$(uname -s | tr '[:upper:]' '[:lower:]')
+  arch=$(uname -m)
+
+  if ! [[ "${system}" =~ ^(linux|darwin)$ ]]; then
+    echo >&2 "install: Unsupported system ${system}."
+    exit 1
+  fi
+
+  case "${arch}" in
+    x86_64|x64) arch=x86_64 ;;
+    aarch64|arm64) arch=arm64 ;;
+    i386|i686) arch=i386 ;;
+    *) echo >&2 "install: Unsupported architecture ${arch}." && exit 1 ;;
+  esac
+
+  if [ "${system}" == "darwin" ] && [ "${arch}" == "i386" ] ; then
+    echo >&2 "install: Unsupported architecture: darwin/i386"
+    exit 1
+  fi
+
+  echo >&2 "install: Downloading terramate binary for ${system}/${arch}"
+
+  url="https://github.com/terramate-io/terramate/releases/download/v${version}/terramate_${version}_${system}_${arch}.tar.gz"
 
   status=$(curl -w "%{http_code}" -o "${tmpdir}/terramate.tar.gz" -L "${url}")
   if [ "${status}" != "200" ] ; then

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ get_latest_version() {
   echo >&2 "get_latest_version: Getting latest Terramate release information from GitHub Releases"
 
   latest_url="https://api.github.com/repos/terramate-io/terramate/releases/latest"
-  latest_json=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" "${latest_url}")
+  latest_json=$(curl -s "${latest_url}")
   tag_version=$(jq -r .tag_name <<<"${latest_json}")
 
   if [ -z "${tag_version}" ] || [ "${tag_version}" == "null" ] ; then


### PR DESCRIPTION
Enables the installation of the supported Terramate Operating System and architectures.
Windows support is still experimental, hence not implemented.