### PR TITLE
fix!: stderr/stdout channel mixup

### DIFF
--- a/terramate-wrapper.sh
+++ b/terramate-wrapper.sh
@@ -5,7 +5,7 @@ tmpdir=$(mktemp -d)
 stdout="${tmpdir}/stdout.txt"
 stderr="${tmpdir}/stderr.txt"
 
-terramate-bin "$@" > >(tee "${stdout}") 2> >(tee "${stderr}")
+terramate-bin "$@" > >(tee "${stdout}") 2> >(tee "${stderr}" >&2)
 
 exitcode=$?
 


### PR DESCRIPTION
This fix sends `stderr` to `stderr` which was before also send to `stdout.

As this changes the content of the streams, we consider it breaking and will release a next major