### PR TITLE
test: check if install still works with current Terramare releases.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [0.4.2, 0.4.3, skip]
+        version: [0.4.2, 0.9.0, skip]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The `latest` is already tested by the `skip` rule, just doing this to trigger the CI tests.
I kept the minimum tested as `v0.4.2`.