### PR TITLE
feat: Remove fallback to latest version and detect instead

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,24 +12,26 @@ defaults:
 
 jobs:
   simple:
-    name: Terramate latest
+    name: Default action without asdf config should fail.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install latest Terramate
+      - name: Install latest Terramate (this will fail)
+        id: install
+        continue-on-error: true
         uses: ./
 
-      - name: Validate execution
-        run: terramate version
+      - name: Validate that previous installation failed
+        run: test "${{steps.install.outcome}}" = "failure"
 
   asdf:
     name: Terramate asdf
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [0.4.2, 0.4.3, skip]
+        version: [0.13.3, 0.14.0, skip]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,9 +45,20 @@ jobs:
         run: echo >.tool-versions
 
       - name: Install asdf Terramate
+        id: install
+        continue-on-error: true
         uses: ./
 
+      - name: Validate that previous installation failed
+        if: ${{ matrix.version == 'skip' }}
+        run: test "${{ steps.install.outcome }}" = "failure"
+
+      - name: Validate that previous installation succeeded
+        if: ${{ matrix.version != 'skip' }}
+        run: test "${{ steps.install.outcome }}" = "success"
+
       - name: Validate execution
+        if: ${{ matrix.version != 'skip' }}
         run: terramate version
 
       - name: Validate version - ${{ matrix.version }}
@@ -63,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [0.4.3, latest]
+        version: [0.14.0, latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -90,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [0.4.3, latest]
+        version: [0.14.0, latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The [`terramate-io/terramate-action`] is a GitHub composite action that sets up Terramate CLI in your GitHub Actions workflows.
 
-- It downloads a specific version or falls back to an [asdf] configured version or the latest available release of [Terramate CLI].
+- It downloads a specific version or a [asdf] configured version of [Terramate CLI].
 - It installs [Terramate CLI] into a user specified path or by default to `/usr/local/bin`
 - It installs a wrapper script by default so that calls to `terramate` binary will expose GitHub Action outputs to access the `stderr`, `stderr`, and the `exitcode` of the `terramate` execution.
 - It allows you to configure a default [Terramate Cloud] organization to use Terramate Cloud Features like Drift Detection and Stack Health Information.
@@ -12,47 +12,46 @@ The [`terramate-io/terramate-action`] is a GitHub composite action that sets up 
 ## Compatbility
 
 The action currently only supports `ubuntu` runners.
-Please open an issue, if more runner support is required.
 
 ## Usage
 
-The default action installs Terramate CLI in it's latest version unless a specific version is configured by [asdf] config file `.tool-versions`.
-
-> [!IMPORTANT]
-> DEPRECATION NOTICE: We will discontinue to support running the terramate action without specifying any version when there is no [asdf] configuration found.
-> This is to safeguard you against accidental upgrades of incompatible terramate version.
+The version argument should be used to specify the desired terramate version to install.
 
 ```yaml
 steps:
-  - uses: terramate-io/terramate-action@v2
+  - uses: terramate-io/terramate-action@v3
+    with:
+      version: "0.14.0"
 ```
 
-You can disable [asdf] integration fallback by explicitly specifying `"latest"` as the desired version.
-
-> [!CAUTION]
-> Using `"latest"` should be avoided for any live workflows. This is purely useful in test or demo environments.
+The default version is `"detect"`.
+The terramate version to use needs to be defined in a `.tool-versions` file as defined by [asdf].
+This is the recommended way to specify the version so updates can be made in a single location.
 
 ```yaml
-steps:
-  - uses: terramate-io/terramate-action@v2
-    with:
-      version: "latest"
+# file: .tool-versions
+terramate 0.14.0
 ```
 
-To install a specific version the version can be specified using the `version` argument:
+```yaml
+steps:
+  - uses: terramate-io/terramate-action@v3
+    with:
+      version: "detect"
+```
+
+or just
 
 ```yaml
 steps:
-  - uses: terramate-io/terramate-action@v2
-    with:
-      version: "0.13.3"
+  - uses: terramate-io/terramate-action@v3
 ```
 
 The binary will be installed to `/usr/local/bin` by default. This location can be changed using the `bindir` argument:
 
 ```yaml
 steps:
-  - uses: terramate-io/terramate-action@v2
+  - uses: terramate-io/terramate-action@v3
     with:
       bindir: /usr/local/bin
 ```
@@ -61,7 +60,7 @@ To configure the default [Terramate Cloud] Organization set `cloud_organization`
 
 ```yaml
 steps:
-  - uses: terramate-io/terramate-action@v2
+  - uses: terramate-io/terramate-action@v3
     with:
       cloud_organization: myorganization
 ```
@@ -70,7 +69,7 @@ To disable using the optional wrapper script by default the `use_wrapper` argume
 
 ```yaml
 steps:
-  - uses: terramate-io/terramate-action@v2
+  - uses: terramate-io/terramate-action@v3
     with:
       use_wrapper: "false"
 ```
@@ -79,9 +78,7 @@ Subsequent steps can access outputs when the wrapper script is installed:
 
 ```yaml
 steps:
-  - uses: terramate-io/terramate-action@v2
-    with:
-      version: "0.13.3"
+  - uses: terramate-io/terramate-action@v3
 
   - id: list
     run: terramate list --changed

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,9 @@ inputs:
   version:
     description: |
       The Terramate Version to install.
-      If not set and an asdf config is available in .tool-versions at the root of the repository is available, the configured version is used by default.
-      If not set and no asdf config is found, the latest version will be installed.
+      If set to "detect" a .tool-versions file needs to exist and configure a terramate version.
     required: false
+    default: "detect"
   bindir:
     description: The destination directory of the installed terramate executable.
     required: false


### PR DESCRIPTION
Remove the fallback to "latest".

Instead use "detect" as a default configuration and allow to set `version: "detect"` to make configuration clear if desired.

Remove "latest" from documentation as it is considered bad practice and shall not be used outside of testing of terramate development.