### PR TITLE
feat: create bindir and add it to PATH

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,3 +150,36 @@ jobs:
       - name: Validate - ${{ matrix.version }}
         if: ${{ matrix.version != 'latest' }}
         run: terramate version | grep ${{ matrix.version }}
+
+  bindir:
+    name: ${{ matrix.product }} ${{ matrix.version }} custom bindir ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+        product:
+          - terramate
+          # - terramate-catalyst
+        version: [0.14.7, latest]
+        include:
+          - product: terramate-catalyst
+            version: 0.14.7-beta2
+            os: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Terramate - ${{ matrix.version }}
+        uses: ./
+        with:
+          version: ${{ matrix.version }}
+          use_wrapper: false
+          use_catalyst: "${{ matrix.product == 'terramate-catalyst'}}"
+          bindir: ${{ runner.temp }}/custom-bin
+
+      - name: Validate execution - ${{ matrix.version }}
+        run: terramate version
+
+      - name: Validate - ${{ matrix.version }}
+        if: ${{ matrix.version != 'latest' }}
+        run: terramate version | grep ${{ matrix.version }}

--- a/install.sh
+++ b/install.sh
@@ -131,6 +131,13 @@ install() {
   echo >&2 "install: extracting terramate binary into ${tmpdir}"
   tar xzf "${tmpdir}/terramate.tar.gz" -C "${tmpdir}" terramate
 
+  mkdir -p "${destdir}"
+  if ! echo "${PATH}" | tr ':' '\n' | grep -Fqx "${destdir}" ; then
+    echo >&2 "install: add ${destdir} to PATH"
+    export PATH="${destdir}:${PATH}"
+    echo "${destdir}" >> ${GITHUB_PATH:-/dev/null}
+  fi
+
   echo >&2 "install: installing terramate into ${destdir}"
   cp "${tmpdir}/terramate" "${destdir}/terramate-bin"
 

--- a/install.sh
+++ b/install.sh
@@ -131,15 +131,15 @@ install() {
   echo >&2 "install: extracting terramate binary into ${tmpdir}"
   tar xzf "${tmpdir}/terramate.tar.gz" -C "${tmpdir}" terramate
 
+  echo >&2 "install: installing terramate into ${destdir}"
   mkdir -p "${destdir}"
+  cp "${tmpdir}/terramate" "${destdir}/terramate-bin"
+
   if ! echo "${PATH}" | tr ':' '\n' | grep -Fqx "${destdir}" ; then
     echo >&2 "install: add ${destdir} to PATH"
     export PATH="${destdir}:${PATH}"
     echo "${destdir}" >> ${GITHUB_PATH:-/dev/null}
   fi
-
-  echo >&2 "install: installing terramate into ${destdir}"
-  cp "${tmpdir}/terramate" "${destdir}/terramate-bin"
 
   if [ "${input_use_wrapper}" != "false" ] && [ -n "${context_github_action_path}" ] ; then
     echo >&2 "install: installing terramate-wrapper into ${destdir}"

--- a/install.sh
+++ b/install.sh
@@ -138,7 +138,7 @@ install() {
   if ! echo "${PATH}" | tr ':' '\n' | grep -Fqx "${destdir}" ; then
     echo >&2 "install: add ${destdir} to PATH"
     export PATH="${destdir}:${PATH}"
-    echo "${destdir}" >> ${GITHUB_PATH:-/dev/null}
+    echo "${destdir}" >> "${GITHUB_PATH:-/dev/null}"
   fi
 
   if [ "${input_use_wrapper}" != "false" ] && [ -n "${context_github_action_path}" ] ; then


### PR DESCRIPTION
This pull request introduces improved support for installing Terramate with a custom binary directory (`bindir`) and ensures that the installation directory is correctly added to the system's `PATH`. These changes enhance the flexibility and reliability of the installation process. 

**Workflow enhancements:**

* Added a new `bindir` job to `.github/workflows/tests.yml` to test installation of Terramate (and optionally Terramate Catalyst) in a custom binary directory across multiple OS and version combinations.

**Installer improvements:**

* Updated `install.sh` to create the custom binary directory if it doesn't exist, add it to the `PATH` if necessary, and record it in the GitHub Actions environment for subsequent steps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the GitHub Action installer script and CI workflow, mainly affecting install location and PATH setup; risk is low but could impact environments with unusual PATH handling.
> 
> **Overview**
> Improves the action installer to better support a custom `bindir`: it now creates the destination directory before copying the binary and ensures the directory is on `PATH` (also writing to `GITHUB_PATH` for subsequent GitHub Actions steps).
> 
> Updates CI by adding a new `bindir` matrix job in `.github/workflows/tests.yml` to validate installs with `use_wrapper: false` into a non-default directory across OS/version combinations (and a Catalyst include case).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24d1e4c00174b9996176f7479401b7baab5adfe3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->