### PR TITLE
fix: apply patch for template injection vulnerability

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,4 +52,6 @@ runs:
     - name: Configuring Terramate execution environment
       if: ${{ inputs.cloud_organization != '' }}
       shell: bash
-      run: echo "TM_CLOUD_ORGANIZATION=${{inputs.cloud_organization}}" >> $GITHUB_ENV
+      env:
+        CLOUD_ORGANIZATION: ${{inputs.cloud_organization}}
+      run: echo "TM_CLOUD_ORGANIZATION=$CLOUD_ORGANIZATION" >> $GITHUB_ENV


### PR DESCRIPTION
Potential injection vulnerability reported by Aikido:
>A GitHub Actions workflow step contains a template expression referencing potentially untrusted GitHub context fields. This may allow malicious input to be injected into shell commands, leading to a potential supply chain attack as tokens of the CI/CD pipeline could be exfiltrated.

>The input `inputs.cloud_organization` is untrusted and used directly, posing a medium risk of injection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a security-sensitive composite action step by changing how `inputs.cloud_organization` is propagated into a shell command; behavior should be equivalent but could affect env var setting if quoting/expansion differs.
> 
> **Overview**
> Updates the composite action to **stop interpolating** `${{ inputs.cloud_organization }}` directly in the `run` command when exporting `TM_CLOUD_ORGANIZATION`.
> 
> The value is now passed via the step `env` (`CLOUD_ORGANIZATION`) and referenced as `$CLOUD_ORGANIZATION` in the shell, reducing exposure to GitHub Actions template injection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a280782b96aa39ee0eb481ab95b3356f8d6e79a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->